### PR TITLE
Bumping version to 1.0.1 so that npm updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,5 @@
     "type": "git",
     "url": "git@git.bgionline.cn:keziyuan/zipkin-instrumentation-koa.git"
   },
-  "version": "1.0.0"
+  "version": "1.0.1"
 }


### PR DESCRIPTION
Without this, people that installed a long time ago will have to manually remove node_modules.